### PR TITLE
Add PJAX Support

### DIFF
--- a/jquery.are-you-sure.js
+++ b/jquery.are-you-sure.js
@@ -108,6 +108,12 @@
       }
     });
 
+    $(document).on('pjax:beforeSend', function() {
+      if ($dirtyForms.length) {
+        return confirm(settings.message);
+      }
+    });
+
     return this.each(function(elem) {
       if (!$(this).is('form')) {
         return;


### PR DESCRIPTION
This pull request adds an event for PJAX's `beforeSend` event. It's not a perfect match for `beforeunload`, as `beforeSend` does not fire if the next page has been cached already. This is more of an issue if you're going back in the browser's history.
