### PR TITLE
Multiple forms can bypass dirty check.

### DIFF
--- a/jquery.are-you-sure.js
+++ b/jquery.are-you-sure.js
@@ -21,7 +21,7 @@
             'fieldSelector' : "select,textarea,input[type='text'],input[type='password'],input[type='checkbox'],input[type='radio'],input[type='hidden']"
           }, options);
 
-    var submittingDirtyForm = null;
+    var submittingForm = null;  // used to filter the form in submission from the dirty check
 
     var getValue = function($field) {
       if ($field.hasClass('ays-ignore')
@@ -116,13 +116,12 @@
 
     if (!settings.silent) {
       $(window).bind('beforeunload', function() {
-        $dirtyForms = $("form").filter('.' + settings.dirtyClass);
+        // Dirty forms that are not the submitting form
+        $dirtyForms = $("form").filter('.' + settings.dirtyClass).not(submittingForm);
+        // end of the line for this information, we either submit or end the process.
+        submittingForm = null;
         if ($dirtyForms.length > 0) {
           // $dirtyForms.removeClass(settings.dirtyClass); // Prevent multiple calls?
-          // if during the submit of a dirty form then re-dirty the form
-          if (submittingDirtyForm != null) {
-            submittingDirtyForm.addClass(settings.dirtyClass);
-          }
           return settings.message;
         }
       });
@@ -135,11 +134,7 @@
       var $form = $(this);
 
       $form.submit(function() {
-        // submitting a dirty form? remember for later
-        if ($form.hasClass(settings.dirtyClass)) {
-          submittingDirtyForm = $form;
-        }
-        $form.removeClass(settings.dirtyClass);
+        submittingForm = $form;
       });
       $form.bind('reset', function() { markDirty($form, false); });
       // Add a custom event to support dynamic addition of new fields


### PR DESCRIPTION
# Problem

Consider a page that contains two forms, both with areYouSure applied. Change fields in both forms so they are both dirty and submit the first form. You are asked if you wish to stay - select to stay. Submit the second form - you are not prompted to stay or leave even though the first form is still dirty. This is because the first form was cleared from being dirty to submit but interrupted and not re-dirtied.
# Solution

Store a reference to the form that is submitting then when checking for dirty forms filter the submitting form out of the results.
# Outstanding issue

If something else stops the submission process between areYouSure's onSubmit and the onBeforeUnload handling then a value will be left in submittingForm causing a form to be always filtered out of dirty checks. No idea how to solve this since there is no onSubmitExit event or such things. Something for people to be aware of I guess.
