### PR TITLE
Keeps dirty form class in body if output is silenced.

### DIFF
--- a/jquery.are-you-sure.js
+++ b/jquery.are-you-sure.js
@@ -11,9 +11,9 @@
  * Date:    18th May 2014
  */
 (function($) {
-  
+
   $.fn.areYouSure = function(options) {
-      
+
     var settings = $.extend(
       {
         'message' : 'You have unsaved changes!',
@@ -78,7 +78,7 @@
         return (getValue($field) != origValue);
       };
 
-      var $form = ($(this).is('form')) 
+      var $form = ($(this).is('form'))
                     ? $(this)
                     : $(this).parents('form');
 
@@ -90,7 +90,7 @@
 
       $fields = $form.find(settings.fieldSelector);
 
-      if (settings.addRemoveFieldsMarksDirty) {              
+      if (settings.addRemoveFieldsMarksDirty) {
         // Check if field count has changed
         var origCount = $form.data("ays-orig-field-count");
         if (origCount != $fields.length) {
@@ -108,7 +108,7 @@
           return false; // break
         }
       });
-      
+
       setDirtyStatus($form, isDirty);
     };
 
@@ -124,7 +124,7 @@
     var setDirtyStatus = function($form, isDirty) {
       var changed = isDirty != $form.hasClass(settings.dirtyClass);
       $form.toggleClass(settings.dirtyClass, isDirty);
-        
+
       // Fire change event if required
       if (changed) {
         if (settings.change) settings.change.call($form, $form);
@@ -175,10 +175,12 @@
         return;
       }
       var $form = $(this);
-        
-      $form.submit(function() {
-        $form.removeClass(settings.dirtyClass);
-      });
+
+      if (!settings.silent) {
+        $form.submit(function() {
+          $form.removeClass(settings.dirtyClass);
+        });
+      }
       $form.bind('reset', function() { setDirtyStatus($form, false); });
       // Add a custom events
       $form.bind('rescan.areYouSure', rescan);


### PR DESCRIPTION
Hi!

I was using this plugin with the `silence: true` setting, and I needed to verify if a form was dirty before submitting.

I noticed the `dirty` class seemed to be disappearing, so I fixed it. Not sure if there was a reason for that.

Here's my code:

``` javascript
$('form').on("submit", function(){
  if($(this).hasClass('dirty')) { 
    // do something 
  }
});
```

Thanks for the plugin :beers: 

Bruno
