### PR TITLE
This allows programmatic changes on select fields to be detected

### DIFF
--- a/jquery.are-you-sure.js
+++ b/jquery.are-you-sure.js
@@ -102,8 +102,8 @@
     var initForm = function($form) {
       var fields = $form.find(settings.fieldSelector);
       $(fields).each(function() { storeOrigValue($(this)); });
-      $(fields).unbind('change keyup', checkForm);
-      $(fields).bind('change keyup', checkForm);
+      $(fields).unbind('focus change keyup', checkForm);
+      $(fields).bind('focus change keyup', checkForm);
       $form.data("ays-orig-field-count", $(fields).length);
       setDirtyStatus($form, false);
     };
@@ -129,7 +129,7 @@
         var $field = $(this);
         if (!$field.data('ays-orig')) {
           storeOrigValue($field);
-          $field.bind('change keyup', checkForm);
+          $field.bind('focus change keyup', checkForm);
         }
       });
       // Check for changes while we're here


### PR DESCRIPTION
The current code is checking against options checked on select fields, this is useless as just calling `.val()` on the select field will return the list of values selected. 
Also, when changing the select value programmatically, the options are not updated with the checked status , which made the plugin fail to detect changes.

I may be missing another point here, so let me know if it's the case ;-)
