### PR TITLE
Fix for select fields with 'multiple' option and no selected values

### DIFF
--- a/jquery.are-you-sure.js
+++ b/jquery.are-you-sure.js
@@ -49,7 +49,9 @@
           val = $field.is(':checked');
           break;
         case 'select':
-          val = $field.val().toString();
+          if($field.val()) {
+            val = $field.val().toString();
+          }
           break;
         default:
           val = $field.val();


### PR DESCRIPTION
In

```
<form>
  <select multiple="multiple" id="foobar" name="foobar">
    <option value="foo">Foo</option>
    <option value="bar">Bar</option>
  </select>
</form>
```

Using

```
$('form').areYouSure();
```

Leads to

```
Uncaught TypeError: Cannot read property 'toString' of null jquery.are-you-sure.js:55
```

This is a fix for that use-case.
