### PR TITLE
Add 'checkDisabled' setting

### DIFF
--- a/jquery.are-you-sure.js
+++ b/jquery.are-you-sure.js
@@ -22,7 +22,8 @@
         'silent' : false,
         'addRemoveFieldsMarksDirty' : false,
         'fieldEvents' : 'change keyup propertychange input',
-        'fieldSelector': ":input:not(input[type=submit]):not(input[type=button])"
+        'fieldSelector': ":input:not(input[type=submit]):not(input[type=button])",
+		'checkDisabled': true
       }, options);
 
     var getValue = function($field) {
@@ -33,7 +34,7 @@
         return null;
       }
 
-      if ($field.is(':disabled')) {
+      if (settings.checkDisabled && $field.is(':disabled')) {
         return 'ays-disabled';
       }
 

--- a/jquery.are-you-sure.js
+++ b/jquery.are-you-sure.js
@@ -23,14 +23,15 @@
         'addRemoveFieldsMarksDirty' : false,
         'fieldEvents' : 'change keyup propertychange input',
         'fieldSelector': ":input:not(input[type=submit]):not(input[type=button])",
-		'checkDisabled': true
+        'checkDisabled': true,
+	'checkAttrName': true
       }, options);
 
     var getValue = function($field) {
       if ($field.hasClass('ays-ignore')
           || $field.hasClass('aysIgnore')
           || $field.attr('data-ays-ignore')
-          || $field.attr('name') === undefined) {
+          || (settings.checkAttrName && $field.attr('name') === undefined)) {
         return null;
       }
 


### PR DESCRIPTION
Add a setting to make it possible enable/disable disabled fields checking.

Useful since 'propertychange' event is not supported by most browsers, so if you change the "disabled" attribute programmatically, the plugin doesn't work properly