### PR TITLE
Allow multiple confirmation messages

### DIFF
--- a/jquery.are-you-sure.js
+++ b/jquery.are-you-sure.js
@@ -117,6 +117,7 @@
       $(fields).each(function() { storeOrigValue($(this)); });
       $(fields).unbind(settings.fieldEvents, checkForm);
       $(fields).bind(settings.fieldEvents, checkForm);
+      $form.data('ays-message', settings.message);
       $form.data("ays-orig-field-count", $(fields).length);
       setDirtyStatus($form, false);
     };
@@ -168,7 +169,7 @@
           window.aysHasPrompted = true;
           window.setTimeout(function() {window.aysHasPrompted = false;}, 900);
         }
-        return settings.message;
+        return $dirtyForms.first().data('aysMessage') || settings.message;
       });
     }
 


### PR DESCRIPTION
This PR adds the ability to set the message on a per-form basis, for the case that you have multiple forms you want checked. For example:

```javascript
$('form.class1').areYouSure( {'message': 'You have unsaved changes to form 1!'} )
$('form.class2').areYouSure( {'message': 'You have unsaved changes to form 2!'} )
```

It's a pretty simple change, and @codedance, please review the return statement; I'm no javascript expert, so there may be some error handling that needs to be done. Also, I'm not sure that it will ever return `settings.message`...