### PR TITLE
Add settings option to initialise the form as dirty

### DIFF
--- a/jquery.are-you-sure.js
+++ b/jquery.are-you-sure.js
@@ -22,7 +22,8 @@
         'silent' : false,
         'addRemoveFieldsMarksDirty' : false,
         'fieldEvents' : 'change keyup propertychange input',
-        'fieldSelector': ":input:not(input[type=submit]):not(input[type=button])"
+        'fieldSelector': ":input:not(input[type=submit]):not(input[type=button])",
+        'startDirty': false
       }, options);
 
     var getValue = function($field) {
@@ -118,7 +119,7 @@
       $(fields).unbind(settings.fieldEvents, checkForm);
       $(fields).bind(settings.fieldEvents, checkForm);
       $form.data("ays-orig-field-count", $(fields).length);
-      setDirtyStatus($form, false);
+      setDirtyStatus($form, settings.startDirty);
     };
 
     var setDirtyStatus = function($form, isDirty) {


### PR DESCRIPTION
I had a need to mark a form as dirty from initialisation (form is part of a multiple page data entry process). This PR adds a setting option to initialise the form as either clean (default) or dirty.