### PR TITLE
Fix brute force checking with `"use strict";`

### DIFF
--- a/jquery.are-you-sure.js
+++ b/jquery.are-you-sure.js
@@ -102,7 +102,7 @@
       // Brute force - check each field
       var isDirty = false;
       $fields.each(function() {
-        $field = $(this);
+        var $field = $(this);
         if (isFieldDirty($field)) {
           isDirty = true;
           return false; // break


### PR DESCRIPTION
I have an old project using this and it is being loaded by Webpack in a `"use strict";` context. Chrome at least throws `Uncaught ReferenceError: $field is not defined` on this line.