### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ doing this simple task in the simplest possible way.
  * Graceful degradation on legacy browsers (i.e. if you're running an old 
    browser... remember to save :-)
 
-###Basic Usage
+### Basic Usage
 
 ```javascript
 
@@ -62,7 +62,7 @@ To ignore selected fields from the dirtyness check:
   </form>
 ```
 
-###Advanced Usage
+### Advanced Usage
 
 ```javascript
 
@@ -166,7 +166,7 @@ The [demo page](http://www.papercut.com/products/free_software/are-you-sure/demo
 shows the advanced usage options in more detail.
 
 
-###Install
+### Install
 Are-You-Sure is a light-weight jQuery plugin - it's a single standalone 
 JavaScript file. You can download the 
 [jquery.are-you-sure.js](https://raw.github.com/codedance/jquery.AreYouSure/master/jquery.are-you-sure.js)
@@ -187,11 +187,11 @@ $ bower install jquery.are-you-sure
 If you're using, or like, *Are-you-sure* make sure you **star/watch** this project
 so you can stay up-to-date with updates.
 
-###Demo
+### Demo
 This [demo page](http://www.papercut.com/products/free_software/are-you-sure/demo/are-you-sure-demo.html)
 hosts a number of example forms.
 
-###Supported Browsers
+### Supported Browsers
 *Are-you-sure* has been tested on and fully supports the following browsers:
 
 * IE 9 through 11
@@ -201,9 +201,9 @@ hosts a number of example forms.
 
 Experimental support is available on iOS and Opera via the *beforeunload* shim (see below).
 
-###Known Issues & Limitations
+### Known Issues & Limitations
 
-####Mobile Safari and Opera
+#### Mobile Safari and Opera
 The ```windows.beforeunload``` event is not supported on iOS (iPhone, iPad, and iPod). An
 experimental shim offering partial *beforeunload* emulation is provided to help plug this gap.
 It works by scanning the page for anchor links and augments the default behaviour to first


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
