### PR TITLE
Fix rescan bug and implement getDirtyFields

### DIFF
--- a/jquery.are-you-sure.js
+++ b/jquery.are-you-sure.js
@@ -68,15 +68,15 @@
       $field.data('ays-orig', getValue($field));
     };
 
-    var checkForm = function(evt) {
+    var isFieldDirty = function($field) {
+      var origValue = $field.data('ays-orig');
+      if (undefined === origValue) {
+        return false;
+      }
+      return (getValue($field) != origValue);
+    };
 
-      var isFieldDirty = function($field) {
-        var origValue = $field.data('ays-orig');
-        if (undefined === origValue) {
-          return false;
-        }
-        return (getValue($field) != origValue);
-      };
+    var checkForm = function(evt) {
 
       var $form = ($(this).is('form'))
                     ? $(this)
@@ -156,7 +156,14 @@
     var getDirtyFields = function() {
       var $form = $(this);
       var fields = $form.find(settings.fieldSelector);
-      return fields.filter(function(field) {return isFieldDirty(field);})
+      var dirtyFields = [];
+      fields.each(function() {
+        if (isFieldDirty($(this))) {
+          dirtyFields.push($(this));
+        }
+      });
+      $(this).data("dirtyFields", dirtyFields);
+      return dirtyFields
     }
 
     if (!settings.silent && !window.aysUnloadSet) {
@@ -189,7 +196,6 @@
       });
       $form.bind('reset', function() { setDirtyStatus($form, false); });
       // Add a custom events
-      $form.bind('isFieldDirty.areYouSure', isFieldDirty);
       $form.bind('getDirtyFields.areYouSure', getDirtyFields);
       $form.bind('rescan.areYouSure', rescan);
       $form.bind('reinitialize.areYouSure', reinitialize);

--- a/jquery.are-you-sure.js
+++ b/jquery.are-you-sure.js
@@ -153,6 +153,12 @@
       initForm($(this));
     }
 
+    var getDirtyFields = function() {
+      var $form = $(this);
+      var fields = $form.find(settings.fieldSelector);
+      return fields.filter(function(field) {return isFieldDirty(field);})
+    }
+
     if (!settings.silent && !window.aysUnloadSet) {
       window.aysUnloadSet = true;
       $(window).bind('beforeunload', function() {
@@ -183,6 +189,8 @@
       });
       $form.bind('reset', function() { setDirtyStatus($form, false); });
       // Add a custom events
+      $form.bind('isFieldDirty.areYouSure', isFieldDirty);
+      $form.bind('getDirtyFields.areYouSure', getDirtyFields);
       $form.bind('rescan.areYouSure', rescan);
       $form.bind('reinitialize.areYouSure', reinitialize);
       $form.bind('checkform.areYouSure', checkForm);

--- a/jquery.are-you-sure.js
+++ b/jquery.are-you-sure.js
@@ -140,7 +140,7 @@
       var fields = $form.find(settings.fieldSelector);
       $(fields).each(function() {
         var $field = $(this);
-        if (!$field.data('ays-orig')) {
+        if (!$field.data('ays-orig') && $field.data('ays-orig') !== "") {
           storeOrigValue($field);
           $field.bind(settings.fieldEvents, checkForm);
         }

--- a/jquery.are-you-sure.js
+++ b/jquery.are-you-sure.js
@@ -11,9 +11,9 @@
  * Date:    13th August 2014
  */
 (function($) {
-  
+
   $.fn.areYouSure = function(options) {
-      
+
     var settings = $.extend(
       {
         'message' : 'You have unsaved changes!',
@@ -78,7 +78,7 @@
         return (getValue($field) != origValue);
       };
 
-      var $form = ($(this).is('form')) 
+      var $form = ($(this).is('form'))
                     ? $(this)
                     : $(this).parents('form');
 
@@ -90,7 +90,7 @@
 
       $fields = $form.find(settings.fieldSelector);
 
-      if (settings.addRemoveFieldsMarksDirty) {              
+      if (settings.addRemoveFieldsMarksDirty) {
         // Check if field count has changed
         var origCount = $form.data("ays-orig-field-count");
         if (origCount != $fields.length) {
@@ -108,7 +108,7 @@
           return false; // break
         }
       });
-      
+
       setDirtyStatus($form, isDirty);
     };
 
@@ -124,7 +124,7 @@
     var setDirtyStatus = function($form, isDirty) {
       var changed = isDirty != $form.hasClass(settings.dirtyClass);
       $form.toggleClass(settings.dirtyClass, isDirty);
-        
+
       // Fire change event if required
       if (changed) {
         if (settings.change) settings.change.call($form, $form);
@@ -177,7 +177,7 @@
         return;
       }
       var $form = $(this);
-        
+
       $form.submit(function() {
         $form.removeClass(settings.dirtyClass);
       });


### PR DESCRIPTION
@codedance 

## Changes
1. Fixing small bug in resan.
2. Exposing getDirtyFields and isDirtyField as available triggers

#### Rescan Bug
Rescan shouldn't be recalculating the original value when the original value is actually an empty string.

My use case that came across this (IMO) bug:
Dynamic form. Add a new blank field to be filled out. Run rescan, which correctly sets the original value of the field to empty string. Then fill in the field, yay it's dirty. Then I add another field. This time rescan incorrectly changes that first field's original value to what I've typed so. Oh no, form suddenly not dirty anymore.

#### Exposing `getDirtyFields`
Also needed some functionality to keep my code cleaner. looks like this was asked for in issue https://github.com/codedance/jquery.AreYouSure/issues/74. So here's my take on that, too.

You can now get the dirty fields:
```
$("#my-form").trigger("getDirtyFIelds.areYouSure").data("dirtyFields");
```
Just adds a data value `dirtyFIelds` in which the array of dirty fields is added. 