### PR TITLE
Use valid SPDX licence in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "Marc Sutton <ashre@iname.com> (http://www.codev.co.uk)"
   ],
   "version": "1.9.0",
-  "license": "MIT/GPLv2",
+  "license": "MIT",
   "keywords": [ "dirty", "form", "onbeforeunload", "save", "check" ],
   "main": "jquery.are-you-sure.js",
   "engines": {


### PR DESCRIPTION
The current specifier is not a valid SPDX expression, see https://docs.npmjs.com/cli/v7/configuring-npm/package-json#license for options on how to declare dual-licensing. Given that the README states that the license is mirroring jQuery, I opted to just copy their value from https://github.com/jquery/jquery/blob/482f846203e82b1c2620f580e483bf41d11f9f49/package.json#L25.